### PR TITLE
Fix problems with payload size

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
           - feature: 52840,
             target: thumbv7em-none-eabihf
             rust: stable
+          - feature: 52832,fast-ru,
+            target: thumbv7em-none-eabihf
+            rust: stable
 
     steps:
       - uses: actions/checkout@v2

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::{Addresses, EsbApp},
+    app::{Addresses, DriverMaximumPayload, EsbApp},
     irq::{EsbIrq, IrqTimer, State},
     peripherals::{EsbRadio, EsbTimer, RADIO},
     Config, Error,
@@ -71,7 +71,6 @@ where
         timer: T,
         radio: RADIO,
         addresses: Addresses,
-        max_payload_bytes: u8,
         config: Config,
     ) -> Result<
         (
@@ -96,6 +95,9 @@ where
         let app = EsbApp {
             prod_to_radio: atr_prod,
             cons_from_radio: rta_cons,
+            maximum_payload: DriverMaximumPayload {
+                inner_checked: config.maximum_payload_size,
+            },
         };
 
         let mut irq = EsbIrq {
@@ -115,7 +117,11 @@ where
             _timer: PhantomData,
         };
 
-        irq.radio.init(max_payload_bytes, &irq.addresses);
+        irq.radio.init(
+            irq.config.maximum_payload_size,
+            irq.config.tx_power,
+            &irq.addresses,
+        );
         irq.timer.init();
 
         Ok((app, irq, irq_timer))

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    app::{Addresses, DriverMaximumPayload, EsbApp},
+    app::{Addresses, EsbApp},
     irq::{EsbIrq, IrqTimer, State},
     peripherals::{EsbRadio, EsbTimer, RADIO},
     Config, Error,
@@ -95,9 +95,7 @@ where
         let app = EsbApp {
             prod_to_radio: atr_prod,
             cons_from_radio: rta_cons,
-            maximum_payload: DriverMaximumPayload {
-                inner_checked: config.maximum_payload_size,
-            },
+            maximum_payload: config.maximum_payload_size,
         };
 
         let mut irq = EsbIrq {

--- a/src/irq.rs
+++ b/src/irq.rs
@@ -334,7 +334,7 @@ where
     {
         if let Ok(grant) = self
             .prod_to_app
-            .grant(self.config.maximum_payload_size.into() + EsbHeader::header_size())
+            .grant(usize::from(self.config.maximum_payload_size) + EsbHeader::header_size())
             .map(PayloadW::new_from_radio)
         {
             f(self, grant)?;

--- a/src/irq.rs
+++ b/src/irq.rs
@@ -334,7 +334,7 @@ where
     {
         if let Ok(grant) = self
             .prod_to_app
-            .grant(self.config.maximum_payload_size as usize + EsbHeader::header_size())
+            .grant(self.config.maximum_payload_size.into() + EsbHeader::header_size())
             .map(PayloadW::new_from_radio)
         {
             f(self, grant)?;

--- a/src/irq.rs
+++ b/src/irq.rs
@@ -144,7 +144,7 @@ where
 
                 let packet = self
                     .prod_to_app
-                    .grant(self.radio.max_payload() as usize + EsbHeader::header_size())
+                    .grant(self.config.maximum_payload_size as usize + EsbHeader::header_size())
                     .map(PayloadW::new_from_radio);
                 if let Ok(packet) = packet {
                     self.radio.prepare_for_ack(packet);
@@ -335,7 +335,7 @@ where
     {
         if let Ok(grant) = self
             .prod_to_app
-            .grant(self.radio.max_payload() as usize + EsbHeader::header_size())
+            .grant(self.config.maximum_payload_size as usize + EsbHeader::header_size())
             .map(PayloadW::new_from_radio)
         {
             f(self, grant)?;

--- a/src/irq.rs
+++ b/src/irq.rs
@@ -294,7 +294,6 @@ where
         self.state = State::IdleRx;
     }
 
-    #[inline]
     fn check_and_clear_flags(&mut self) -> Events {
         let evts = Events {
             disabled: self.radio.check_disabled_event(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,13 @@
 //!
 //! The maximum in-queue packet size is 258 bytes (with a 252 bytes payload).
 //!
+//! # Compatibility with nRF24L01+
+//!
+//! This implementation is only compatible with nRF24L01+ devices when using a
+//! [configuration](struct.Config.html) with a maximum packet size no bigger than 32 bytes
+//! (inclusive). That is required because the nRF24L01+ only supports payloads up to that size and
+//! uses a 6-bits effective payload length that must be configured in the nRF5 radio.
+//!
 //! # Examples
 //!
 //! Usage examples can be found at the [demos repo](https://github.com/thalesfragoso/esb-demos).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,19 @@
 //! communicating with devices that do not support it, the timing configuration must take this case
 //! into account.
 //!
+//! # In-queue packet representation
+//!
+//! This crate uses some bytes of queue space to pass information between the user and the driver.
+//! The user must take this into account when choosing the size of the
+//! [EsbBuffer](buffer/struct.EsbBuffer.html). Moreover, the characteristics of the underlying
+//! BipBuffer must be considered, for more information refer to [bbqueue docs](https://docs.rs/bbqueue).
+//!
+//! | Used by bbqueue framed    | SW USE                         |               ACTUAL DMA PART                                      |
+//! | :---                      | :---                           | :---                                                               |
+//! | frame_size - 1 to 2 bytes | rssi - 1 byte \| pipe - 1 byte | length - 1 byte \| pid_no_ack - 1 byte \| payload - 1 to 252 bytes |
+//!
+//! The maximum in-queue packet size is 258 bytes (with a 252 bytes payload).
+//!
 //! # Examples
 //!
 //! Usage examples can be found at the [demos repo](https://github.com/thalesfragoso/esb-demos).
@@ -136,18 +149,29 @@ pub enum Error {
     MaximumAttempts,
 }
 
+/// Tx Power
+pub type TxPower = peripherals::TXPOWER_A;
+
 /// Protocol configuration
 #[derive(Copy, Clone)]
 pub struct Config {
     /// Number of microseconds to wait for an acknowledgement before timing out
     wait_for_ack_timeout: u16,
-    /// Delay, in microseconds, between retransmissions when the radio does not receive an acknowledgement
+    /// Delay, in microseconds, between retransmissions when the radio does not receive an
+    /// acknowledgement
     retransmit_delay: u16,
     /// Maximum number of transmit attempts when an acknowledgement is not received
     maximum_transmit_attempts: u8,
     /// A bit mask representing the pipes that the radio must listen while receiving, the LSb is
     /// pipe zero
     enabled_pipes: u8,
+    /// Tx Power
+    tx_power: TxPower,
+    /// Maximum payload size in bytes that the driver will send or receive.
+    ///
+    /// This allows for a more efficient usage of the receiver queue and makes this driver
+    /// compatible with nRF24L01+ modules when this size is 32 bytes or less
+    maximum_payload_size: u8,
 }
 
 impl Default for Config {
@@ -157,6 +181,8 @@ impl Default for Config {
             retransmit_delay: RETRANSMIT_DELAY,
             maximum_transmit_attempts: MAXIMUM_TRANSMIT_ATTEMPTS,
             enabled_pipes: ENABLED_PIPES,
+            tx_power: TxPower::_0DBM,
+            maximum_payload_size: 252,
         }
     }
 }
@@ -191,6 +217,8 @@ impl Default for Config {
 /// | Retransmit Delay                    | 500 us        |
 /// | Maximum number of transmit attempts | 3             |
 /// | Enabled Pipes                       | 0xFF          |
+/// | Tx Power                            | 0dBm          |
+/// | Maximum payload size                | 252 bytes     |
 ///
 pub struct ConfigBuilder(Config);
 
@@ -201,29 +229,41 @@ impl Default for ConfigBuilder {
 }
 
 impl ConfigBuilder {
-    /// Sets `wait_for_ack_timeout` field, must be bigger than 43 us
+    /// Sets number of microseconds to wait for an acknowledgement before timing out
     pub fn wait_for_ack_timeout(mut self, micros: u16) -> Self {
         self.0.wait_for_ack_timeout = micros;
         self
     }
 
     // TODO: document 62
-    /// Sets `retransmit_delay` field, must be bigger than `wait_for_ack_timeout` field plus 62 and
-    /// bigger than the ramp-up time (140us without fast-ru and 40us with fast-ru)
+    /// Sets retransmit delay, must be bigger than `wait_for_ack_timeout` field plus 62 and bigger
+    /// than the ramp-up time (140us without fast-ru and 40us with fast-ru)
     pub fn retransmit_delay(mut self, micros: u16) -> Self {
         self.0.retransmit_delay = micros;
         self
     }
 
-    /// Sets `maximum_transmit_attempts` field
+    /// Sets maximum number of transmit attempts
     pub fn maximum_transmit_attempts(mut self, n: u8) -> Self {
         self.0.maximum_transmit_attempts = n;
         self
     }
 
-    /// Sets `enabled_pipes` field
+    /// Sets enabled pipes for receiving
     pub fn enabled_pipes(mut self, enabled_pipes: u8) -> Self {
         self.0.enabled_pipes = enabled_pipes;
+        self
+    }
+
+    /// Sets the tx power
+    pub fn tx_power(mut self, tx_power: TxPower) -> Self {
+        self.0.tx_power = tx_power;
+        self
+    }
+
+    /// Sets the maximum payload size
+    pub fn max_payload_size(mut self, payload_size: u8) -> Self {
+        self.0.maximum_payload_size = payload_size;
         self
     }
 
@@ -232,8 +272,9 @@ impl ConfigBuilder {
         let bad_retransmit_delay = self.0.retransmit_delay
             <= self.0.wait_for_ack_timeout + RETRANSMIT_DELAY_US_OFFSET
             || self.0.retransmit_delay <= RAMP_UP_TIME;
+        let bad_size = self.0.maximum_payload_size > 252;
 
-        if bad_ack_timeout || bad_retransmit_delay {
+        if bad_ack_timeout || bad_retransmit_delay || bad_size {
             Err(Error::InvalidParameters)
         } else {
             Ok(self.0)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,9 @@ pub enum Error {
     /// Values out of range
     InvalidParameters,
 
+    // The requested packet was larger than the configured max payload size
+    MaximumPacketExceeded,
+
     /// Internal Error, if you encounter this error, please report it, it is a bug
     InternalError,
 

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,4 +1,4 @@
-use crate::Error;
+use crate::{app::DriverMaximumPayload, Error};
 use bbqueue::{
     framed::{FrameGrantR, FrameGrantW},
     ArrayLength,
@@ -16,14 +16,17 @@ use core::ops::{Deref, DerefMut};
 /// ## Example
 ///
 /// ```rust
+/// # use esb::app::DriverMaximumPayload;
 /// use esb::EsbHeaderBuilder;
 ///
+/// # let driver_maximum_payload = unsafe { DriverMaximumPayload::new_unchecked(252) };
+/// // `driver_maximum_payload` can be acquired through EsbApp::maximum_payload_size
 /// let header_result = EsbHeaderBuilder::default()
 ///     .max_payload(252)
 ///     .pid(0)
 ///     .pipe(0)
 ///     .no_ack(true)
-///     .check();
+///     .check(driver_maximum_payload);
 ///
 /// assert!(header_result.is_ok());
 /// ```
@@ -90,10 +93,9 @@ impl EsbHeaderBuilder {
 
     /// Finalize the header.
     ///
-    /// If the set parameters are out of range, an error will
-    /// be returned.
-    pub fn check(self) -> Result<EsbHeader, Error> {
-        let bad_length = self.0.length > 252;
+    /// If the set parameters are out of range, an error will be returned.
+    pub fn check(self, driver_maximum_payload: DriverMaximumPayload) -> Result<EsbHeader, Error> {
+        let bad_length = self.0.length > driver_maximum_payload.inner_checked;
         let bad_pipe = self.0.pipe > 7;
 
         // This checks if "pid" > 3, where pid_no_ack is pid << 1.
@@ -116,20 +118,24 @@ impl EsbHeaderBuilder {
 /// ## Example
 ///
 /// ```rust
+/// # use esb::app::DriverMaximumPayload;
 /// use esb::EsbHeader;
 ///
+/// # let driver_maximum_payload = unsafe { DriverMaximumPayload::new_unchecked(252) };
+/// // `driver_maximum_payload` can be acquired through EsbApp::maximum_payload_size
 /// let builder_result = EsbHeader::build()
 ///     .max_payload(252)
 ///     .pid(0)
 ///     .pipe(1)
 ///     .no_ack(true)
-///     .check();
+///     .check(driver_maximum_payload);
 ///
 /// let new_result = EsbHeader::new(
 ///     252,
 ///     0,
 ///     1,
 ///     true,
+///     driver_maximum_payload,
 /// );
 ///
 /// assert_eq!(builder_result, new_result);
@@ -166,13 +172,19 @@ impl EsbHeader {
     /// * `max_payload_length` must be between 0 and 252 bytes, inclusive.
     /// * `pid` must be between 0 and 3, inclusive.
     /// * `pipe` must be between 0 and 7, inclusive.
-    pub fn new(max_payload_length: u8, pid: u8, pipe: u8, no_ack: bool) -> Result<Self, Error> {
+    pub fn new(
+        max_payload_length: u8,
+        pid: u8,
+        pipe: u8,
+        no_ack: bool,
+        driver_maximum_payload: DriverMaximumPayload,
+    ) -> Result<Self, Error> {
         EsbHeaderBuilder::default()
             .max_payload(max_payload_length)
             .pid(pid)
             .pipe(pipe)
             .no_ack(no_ack)
-            .check()
+            .check(driver_maximum_payload)
     }
 
     /// convert into a packed representation meant for internal

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -165,12 +165,7 @@ impl EsbHeader {
     /// * `max_payload_length` must be between 0 and 252 bytes, inclusive.
     /// * `pid` must be between 0 and 3, inclusive.
     /// * `pipe` must be between 0 and 7, inclusive.
-    pub fn new(
-        max_payload_length: u8,
-        pid: u8,
-        pipe: u8,
-        no_ack: bool,
-    ) -> Result<Self, Error> {
+    pub fn new(max_payload_length: u8, pid: u8, pipe: u8, no_ack: bool) -> Result<Self, Error> {
         EsbHeaderBuilder::default()
             .max_payload(max_payload_length)
             .pid(pid)


### PR DESCRIPTION
In the current state, we don't check the payload size of an `EsbHeader` against the maximum size passed by the user when configuring the driver. This can cause problems since we use that to set the number of bits of the length field in the radio hardware.

This PR allows for a more efficient usage of the receiver queue and makes this driver compatible with nRF24L01+ modules when maximum payload size is 32 bytes or less.

@jamesmunns I would appreciate your opinion in this solution, since it makes the creation of an `EsbHeader` a little bit more cumbersome.