### PR TITLE
Separate PTX and PRX through type-state

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -65,7 +65,8 @@ where
 
     /// Starts the radio sending all packets in the queue.
     ///
-    /// The radio will send until the queue has been drained.
+    /// The radio will send until the queue has been drained. This method must be called again if
+    /// the queue is completely drained before the user commits new packets.
     #[inline]
     pub fn start_tx(&mut self) {
         // TODO(AJM): Is this appropriate for PRX? Or is this a PTX-only
@@ -83,7 +84,7 @@ where
         self.cons_from_radio.read().is_some()
     }
 
-    /// Attempt to read a packet that has been received via the radio
+    /// Attempt to read a packet that has been received via the radio.
     ///
     /// Returns `Some(PayloadR)` if a packet is ready to be read,
     /// otherwise `None`.
@@ -91,7 +92,7 @@ where
         self.cons_from_radio.read().map(PayloadR::new)
     }
 
-    /// Gets the maximum payload size (in bytes) that the driver was configured to use
+    /// Gets the maximum payload size (in bytes) that the driver was configured to use.
     #[inline]
     pub fn maximum_payload_size(&self) -> usize {
         self.maximum_payload.into()

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -1,6 +1,6 @@
 use crate::{
     app::{Addresses, EsbApp},
-    irq::{EsbIrq, IrqTimer, State},
+    irq::{Disabled, EsbIrq, IrqTimer},
     peripherals::{EsbRadio, EsbTimer, RADIO},
     Config, Error,
 };
@@ -75,7 +75,7 @@ where
     ) -> Result<
         (
             EsbApp<OutgoingLen, IncomingLen>,
-            EsbIrq<OutgoingLen, IncomingLen, T>,
+            EsbIrq<OutgoingLen, IncomingLen, T, Disabled>,
             IrqTimer<T>,
         ),
         Error,
@@ -103,7 +103,7 @@ where
             cons_from_app: atr_cons,
             timer,
             radio: EsbRadio::new(radio),
-            state: State::IdleTx,
+            state: Disabled,
             addresses,
             attempts: 0,
             timer_flag: &self.timer_flag,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@ pub mod payload;
 pub use crate::{
     app::{Addresses, EsbApp},
     buffer::EsbBuffer,
-    irq::{EsbIrq, IrqTimer, State},
+    irq::{EsbIrq, IrqTimer},
     payload::{EsbHeader, EsbHeaderBuilder},
 };
 


### PR DESCRIPTION
I did a quick compile test and this change managed to save a couple of kbs when using only one of the modes (PTX or PRX).

~~I still need to test this branch better in hardware.~~