### PR TITLE
Update PAC version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ features = ["52832"]
 default-target = "x86_64-unknown-linux-gnu"
 
 [dependencies]
-nrf51 = { version = "0.9.0", optional = true }
+nrf51 = { version = "0.10.0", optional = true }
 nrf52810-pac = { version = "0.10.0", optional = true }
 nrf52832-pac = { version = "0.10.0", optional = true }
 nrf52840-pac = { version = "0.10.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ features = ["52832"]
 default-target = "x86_64-unknown-linux-gnu"
 
 [dependencies]
-nrf51 = { version = "0.10.0", optional = true }
+nrf51-pac = { version = "0.10.0", optional = true }
 nrf52810-pac = { version = "0.10.0", optional = true }
 nrf52832-pac = { version = "0.10.0", optional = true }
 nrf52840-pac = { version = "0.10.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,10 @@ features = ["52832"]
 default-target = "x86_64-unknown-linux-gnu"
 
 [dependencies]
-nrf51 = { version = "0.10.0", optional = true }
-nrf52810-pac = { version = "0.10.0", optional = true }
-nrf52832-pac = { version = "0.10.0", optional = true }
-nrf52840-pac = { version = "0.10.0", optional = true }
+nrf51 = { version = "0.10.1", optional = true }
+nrf52810-pac = { version = "0.10.1", optional = true }
+nrf52832-pac = { version = "0.10.1", optional = true }
+nrf52840-pac = { version = "0.10.1", optional = true }
 log = { version = "0.4.8", optional = true }
 
 [dependencies.bbqueue]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ features = ["52832"]
 default-target = "x86_64-unknown-linux-gnu"
 
 [dependencies]
-nrf51 = { version = "0.10.1", optional = true }
+nrf51-pac = { version = "0.10.1", optional = true }
 nrf52810-pac = { version = "0.10.1", optional = true }
 nrf52832-pac = { version = "0.10.1", optional = true }
 nrf52840-pac = { version = "0.10.1", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ default-target = "x86_64-unknown-linux-gnu"
 
 [dependencies]
 nrf51 = { version = "0.9.0", optional = true }
-nrf52810-pac = { version = "0.9.0", optional = true }
-nrf52832-pac = { version = "0.9.0", optional = true }
-nrf52840-pac = { version = "0.9.0", optional = true }
+nrf52810-pac = { version = "0.10.0", optional = true }
+nrf52832-pac = { version = "0.10.0", optional = true }
+nrf52840-pac = { version = "0.10.0", optional = true }
 log = { version = "0.4.8", optional = true }
 
 [dependencies.bbqueue]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ default-features = false
 
 [features]
 fast-ru = []
-51 = ["nrf51", "bbqueue/thumbv6"]
+51 = ["nrf51-pac", "bbqueue/thumbv6"]
 52810 = ["nrf52810-pac", "bbqueue/atomic"]
 52832 = ["nrf52832-pac", "bbqueue/atomic"]
 52840 = ["nrf52840-pac", "bbqueue/atomic"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ default-target = "x86_64-unknown-linux-gnu"
 nrf51-pac = { version = "0.10.1", optional = true }
 nrf52810-pac = { version = "0.10.1", optional = true }
 nrf52832-pac = { version = "0.10.1", optional = true }
+nrf52833-pac = { version = "0.10.1", optional = true }
 nrf52840-pac = { version = "0.10.1", optional = true }
 log = { version = "0.4.8", optional = true }
 
@@ -37,4 +38,5 @@ fast-ru = []
 51 = ["nrf51-pac", "bbqueue/thumbv6"]
 52810 = ["nrf52810-pac", "bbqueue/atomic"]
 52832 = ["nrf52832-pac", "bbqueue/atomic"]
+52833 = ["nrf52833-pac", "bbqueue/atomic"]
 52840 = ["nrf52840-pac", "bbqueue/atomic"]

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -7,6 +7,9 @@ use nrf52810_pac as pac;
 #[cfg(feature = "52832")]
 use nrf52832_pac as pac;
 
+#[cfg(feature = "52833")]
+use nrf52833_pac as pac;
+
 #[cfg(feature = "52840")]
 use nrf52840_pac as pac;
 

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "51")]
-use nrf51 as pac;
+use nrf51_pac as pac;
 
 #[cfg(feature = "52810")]
 use nrf52810_pac as pac;


### PR DESCRIPTION
Without this patch, this crate doesn't compile on the current PAC, with errors like this: `^ the trait `EsbTimer` is not implemented for `nrf_hal::nrf52840_pac::TIMER0``.