### PR TITLE
Update bbqueue 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- Update bbqueue to `0.4.10`.
+- Update bbqueue to `0.5.1`.
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,16 @@ nrf52840-pac = { version = "0.10.1", optional = true }
 log = { version = "0.4.8", optional = true }
 
 [dependencies.bbqueue]
-version = "0.4.10"
+version = "0.5.1"
 default-features = false
 
 [features]
 fast-ru = []
-51 = ["nrf51-pac", "bbqueue/thumbv6"]
-52810 = ["nrf52810-pac", "bbqueue/atomic"]
-52832 = ["nrf52832-pac", "bbqueue/atomic"]
-52833 = ["nrf52833-pac", "bbqueue/atomic"]
-52840 = ["nrf52840-pac", "bbqueue/atomic"]
+51 = ["nrf51-pac"]
+52810 = ["nrf52810-pac"]
+52832 = ["nrf52832-pac"]
+52833 = ["nrf52833-pac"]
+52840 = ["nrf52840-pac"]
+
+# TODO: Don't commit!
+default = ["52840"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,11 +39,8 @@ default-features = false
 
 [features]
 fast-ru = []
-51 = ["nrf51-pac"]
+51 = ["nrf51-pac", "bbqueue/thumbv6"]
 52810 = ["nrf52810-pac"]
 52832 = ["nrf52832-pac"]
 52833 = ["nrf52833-pac"]
 52840 = ["nrf52840-pac"]
-
-# TODO: Don't commit!
-default = ["52840"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,10 @@
 [package]
 name = "esb"
+
+# TODO: Breaking changes since 0.1.x! Must be updated
+# before release!
 version = "0.1.0"
+
 edition = "2018"
 description = "Implementation of Nordic's Enhanced ShockBurst communication protocol"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ description = "Implementation of Nordic's Enhanced ShockBurst communication prot
 
 authors = [
     "Thales Fragoso <thales.fragosoz@gmail.com>",
-    "James Munns <james.munns@ferrous-systems.com>"
+    "James Munns <james@onevariable.com>"
 ]
 
 repository = "https://github.com/thalesfragoso/esb"

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,8 +14,7 @@ use core::default::Default;
 /// It is intended to be used outside of the `RADIO` interrupt,
 /// and allows for sending or receiving frames from the ESB Radio
 /// hardware.
-pub struct EsbApp<const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
-{
+pub struct EsbApp<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> {
     // TODO(AJM): Make a constructor for this so we don't
     // need to make these fields pub(crate)
     pub(crate) prod_to_radio: FrameProducer<'static, OUTGOING_LEN>,
@@ -23,8 +22,7 @@ pub struct EsbApp<const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
     pub(crate) maximum_payload: u8,
 }
 
-impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbApp<OUTGOING_LEN, INCOMING_LEN>
-{
+impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbApp<OUTGOING_LEN, INCOMING_LEN> {
     /// Obtain a grant for an outgoing packet to be sent over the Radio
     ///
     /// When space is available, this function will return a [`PayloadW`],

--- a/src/app.rs
+++ b/src/app.rs
@@ -14,16 +14,16 @@ use core::default::Default;
 /// It is intended to be used outside of the `RADIO` interrupt,
 /// and allows for sending or receiving frames from the ESB Radio
 /// hardware.
-pub struct EsbApp<const OutgoingLen: usize, const IncomingLen: usize>
+pub struct EsbApp<const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
 {
     // TODO(AJM): Make a constructor for this so we don't
     // need to make these fields pub(crate)
-    pub(crate) prod_to_radio: FrameProducer<'static, OutgoingLen>,
-    pub(crate) cons_from_radio: FrameConsumer<'static, IncomingLen>,
+    pub(crate) prod_to_radio: FrameProducer<'static, OUTGOING_LEN>,
+    pub(crate) cons_from_radio: FrameConsumer<'static, INCOMING_LEN>,
     pub(crate) maximum_payload: u8,
 }
 
-impl<const OutgoingLen: usize, const IncomingLen: usize> EsbApp<OutgoingLen, IncomingLen>
+impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbApp<OUTGOING_LEN, INCOMING_LEN>
 {
     /// Obtain a grant for an outgoing packet to be sent over the Radio
     ///
@@ -39,7 +39,7 @@ impl<const OutgoingLen: usize, const IncomingLen: usize> EsbApp<OutgoingLen, Inc
     /// `drop` the old grant, and create a new one.
     ///
     /// Only one grant may be active at a time.
-    pub fn grant_packet(&mut self, header: EsbHeader) -> Result<PayloadW<OutgoingLen>, Error> {
+    pub fn grant_packet(&mut self, header: EsbHeader) -> Result<PayloadW<OUTGOING_LEN>, Error> {
         // Check we have not exceeded the configured packet max
         if header.length > self.maximum_payload {
             return Err(Error::MaximumPacketExceeded);
@@ -82,7 +82,7 @@ impl<const OutgoingLen: usize, const IncomingLen: usize> EsbApp<OutgoingLen, Inc
     ///
     /// Returns `Some(PayloadR)` if a packet is ready to be read,
     /// otherwise `None`.
-    pub fn read_packet(&mut self) -> Option<PayloadR<IncomingLen>> {
+    pub fn read_packet(&mut self) -> Option<PayloadR<INCOMING_LEN>> {
         self.cons_from_radio.read().map(PayloadR::new)
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use bbqueue::{
     framed::{FrameConsumer, FrameProducer},
-    ArrayLength, Error as BbqError,
+    Error as BbqError,
 };
 use core::default::Default;
 
@@ -14,10 +14,7 @@ use core::default::Default;
 /// It is intended to be used outside of the `RADIO` interrupt,
 /// and allows for sending or receiving frames from the ESB Radio
 /// hardware.
-pub struct EsbApp<OutgoingLen, IncomingLen>
-where
-    OutgoingLen: ArrayLength<u8>,
-    IncomingLen: ArrayLength<u8>,
+pub struct EsbApp<const OutgoingLen: usize, const IncomingLen: usize>
 {
     // TODO(AJM): Make a constructor for this so we don't
     // need to make these fields pub(crate)
@@ -26,10 +23,7 @@ where
     pub(crate) maximum_payload: u8,
 }
 
-impl<OutgoingLen, IncomingLen> EsbApp<OutgoingLen, IncomingLen>
-where
-    OutgoingLen: ArrayLength<u8>,
-    IncomingLen: ArrayLength<u8>,
+impl<const OutgoingLen: usize, const IncomingLen: usize> EsbApp<OutgoingLen, IncomingLen>
 {
     /// Obtain a grant for an outgoing packet to be sent over the Radio
     ///

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -17,41 +17,41 @@ use core::{
 ///
 /// ## Creating at static scope
 ///
-/// Currently due to lacking const generics, the UX for this
-/// isn't great. You'll probably want something like this:
-///
-/// ## NOTE
-///
-/// Although the members of this struct are public, due to const
-/// generic limitations, they are not intended to be used directly,
-/// outside of `static` creation.
-///
-/// This could cause unintended, though not undefined, behavior.
-///
-/// TL;DR: It's not unsafe, but it's also not going to work correctly.
-///
 /// ```rust
 /// // This creates an ESB storage structure with room for
 /// // 512 bytes of outgoing packets (including headers),
 /// // and 256 bytes of incoming packets (including
 /// // headers).
-/// # use esb::{BBBuffer, EsbBuffer};
-/// # use core::sync::atomic::AtomicBool;
-/// static BUFFER: EsbBuffer<512, 256> = EsbBuffer {
-///     app_to_radio_buf: BBBuffer::new(),
-///     radio_to_app_buf: BBBuffer::new(),
-///     timer_flag: AtomicBool::new(false),
-/// };
+/// # use esb::EsbBuffer;
+/// static BUFFER: EsbBuffer<512, 256> = EsbBuffer::new();
 /// ```
 pub struct EsbBuffer<const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
 {
-    pub app_to_radio_buf: BBBuffer<OUTGOING_LEN>,
-    pub radio_to_app_buf: BBBuffer<INCOMING_LEN>,
-    pub timer_flag: AtomicBool,
+    pub(crate) app_to_radio_buf: BBBuffer<OUTGOING_LEN>,
+    pub(crate) radio_to_app_buf: BBBuffer<INCOMING_LEN>,
+    pub(crate) timer_flag: AtomicBool,
 }
 
 impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbBuffer<OUTGOING_LEN, INCOMING_LEN>
 {
+    /// Create a new EsbBuffer. This is typically to be done at static scope/lifetime.
+    ///
+    /// ```rust
+    /// // This creates an ESB storage structure with room for
+    /// // 512 bytes of outgoing packets (including headers),
+    /// // and 256 bytes of incoming packets (including
+    /// // headers).
+    /// # use esb::EsbBuffer;
+    /// static BUFFER: EsbBuffer<512, 256> = EsbBuffer::new();
+    /// ```
+    pub const fn new() -> Self {
+        EsbBuffer {
+            app_to_radio_buf: BBBuffer::new(),
+            radio_to_app_buf: BBBuffer::new(),
+            timer_flag: AtomicBool::new(false),
+        }
+    }
+
     /// Attempt to split the `static` buffer into handles for Interrupt and App context
     ///
     /// This function will only succeed once. If the underlying buffers have also

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -25,15 +25,13 @@ use core::{
 /// # use esb::EsbBuffer;
 /// static BUFFER: EsbBuffer<512, 256> = EsbBuffer::new();
 /// ```
-pub struct EsbBuffer<const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
-{
+pub struct EsbBuffer<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> {
     pub(crate) app_to_radio_buf: BBBuffer<OUTGOING_LEN>,
     pub(crate) radio_to_app_buf: BBBuffer<INCOMING_LEN>,
     pub(crate) timer_flag: AtomicBool,
 }
 
-impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbBuffer<OUTGOING_LEN, INCOMING_LEN>
-{
+impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbBuffer<OUTGOING_LEN, INCOMING_LEN> {
     /// Create a new EsbBuffer. This is typically to be done at static scope/lifetime.
     ///
     /// ```rust

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -4,7 +4,7 @@ use crate::{
     peripherals::{EsbRadio, EsbTimer, RADIO},
     Config, Error,
 };
-use bbqueue::{ArrayLength, BBBuffer};
+use bbqueue::BBBuffer;
 use core::{
     marker::PhantomData,
     sync::atomic::{AtomicBool, Ordering},
@@ -35,28 +35,22 @@ use core::{
 /// // 512 bytes of outgoing packets (including headers),
 /// // and 256 bytes of incoming packets (including
 /// // headers).
-/// # use esb::{BBBuffer, consts::*, ConstBBBuffer, EsbBuffer};
+/// # use esb::{BBBuffer, EsbBuffer};
 /// # use core::sync::atomic::AtomicBool;
-/// static BUFFER: EsbBuffer<U512, U256> = EsbBuffer {
-///     app_to_radio_buf: BBBuffer( ConstBBBuffer::new() ),
-///     radio_to_app_buf: BBBuffer( ConstBBBuffer::new() ),
+/// static BUFFER: EsbBuffer<512, 256> = EsbBuffer {
+///     app_to_radio_buf: BBBuffer::new(),
+///     radio_to_app_buf: BBBuffer::new(),
 ///     timer_flag: AtomicBool::new(false),
 /// };
 /// ```
-pub struct EsbBuffer<OutgoingLen, IncomingLen>
-where
-    OutgoingLen: ArrayLength<u8>,
-    IncomingLen: ArrayLength<u8>,
+pub struct EsbBuffer<const OutgoingLen: usize, const IncomingLen: usize>
 {
     pub app_to_radio_buf: BBBuffer<OutgoingLen>,
     pub radio_to_app_buf: BBBuffer<IncomingLen>,
     pub timer_flag: AtomicBool,
 }
 
-impl<OutgoingLen, IncomingLen> EsbBuffer<OutgoingLen, IncomingLen>
-where
-    OutgoingLen: ArrayLength<u8>,
-    IncomingLen: ArrayLength<u8>,
+impl<const OutgoingLen: usize, const IncomingLen: usize> EsbBuffer<OutgoingLen, IncomingLen>
 {
     /// Attempt to split the `static` buffer into handles for Interrupt and App context
     ///
@@ -75,7 +69,7 @@ where
     ) -> Result<
         (
             EsbApp<OutgoingLen, IncomingLen>,
-            EsbIrq<OutgoingLen, IncomingLen, T, Disabled>,
+            EsbIrq<T, Disabled, OutgoingLen, IncomingLen>,
             IrqTimer<T>,
         ),
         Error,

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -43,14 +43,14 @@ use core::{
 ///     timer_flag: AtomicBool::new(false),
 /// };
 /// ```
-pub struct EsbBuffer<const OutgoingLen: usize, const IncomingLen: usize>
+pub struct EsbBuffer<const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
 {
-    pub app_to_radio_buf: BBBuffer<OutgoingLen>,
-    pub radio_to_app_buf: BBBuffer<IncomingLen>,
+    pub app_to_radio_buf: BBBuffer<OUTGOING_LEN>,
+    pub radio_to_app_buf: BBBuffer<INCOMING_LEN>,
     pub timer_flag: AtomicBool,
 }
 
-impl<const OutgoingLen: usize, const IncomingLen: usize> EsbBuffer<OutgoingLen, IncomingLen>
+impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbBuffer<OUTGOING_LEN, INCOMING_LEN>
 {
     /// Attempt to split the `static` buffer into handles for Interrupt and App context
     ///
@@ -68,8 +68,8 @@ impl<const OutgoingLen: usize, const IncomingLen: usize> EsbBuffer<OutgoingLen, 
         config: Config,
     ) -> Result<
         (
-            EsbApp<OutgoingLen, IncomingLen>,
-            EsbIrq<T, Disabled, OutgoingLen, IncomingLen>,
+            EsbApp<OUTGOING_LEN, INCOMING_LEN>,
+            EsbIrq<T, Disabled, OUTGOING_LEN, INCOMING_LEN>,
             IrqTimer<T>,
         ),
         Error,

--- a/src/irq.rs
+++ b/src/irq.rs
@@ -70,21 +70,21 @@ impl<T: EsbTimer> IrqTimer<T> {
 /// It is intended to be used inside of the `RADIO` interrupt,
 /// and allows for sending or receiving frames from the Application
 /// hardware.
-pub struct EsbIrq<Timer, STATE, const OutgoingLen: usize, const IncomingLen: usize>
+pub struct EsbIrq<Timer, STATE, const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
 where
     Timer: EsbTimer,
 {
     /// Producer to send incoming frames FROM the radio, TO the application
-    pub(crate) prod_to_app: FrameProducer<'static, IncomingLen>,
+    pub(crate) prod_to_app: FrameProducer<'static, INCOMING_LEN>,
 
     /// Consumer to receive outgoing frames TO the radio, FROM the application
-    pub(crate) cons_from_app: FrameConsumer<'static, OutgoingLen>,
+    pub(crate) cons_from_app: FrameConsumer<'static, OUTGOING_LEN>,
 
     /// Peripheral timer, use for ACK and other timeouts
     pub(crate) timer: Timer,
 
     /// Wrapping structure of the nRF RADIO peripheral
-    pub(crate) radio: EsbRadio<OutgoingLen, IncomingLen>,
+    pub(crate) radio: EsbRadio<OUTGOING_LEN, INCOMING_LEN>,
 
     /// Current state of the Radio/IRQ task
     pub(crate) state: STATE,
@@ -107,12 +107,12 @@ struct Events {
     timer: bool,
 }
 
-impl<Timer, STATE, const OutgoingLen: usize, const IncomingLen: usize> EsbIrq<Timer, STATE, OutgoingLen, IncomingLen>
+impl<Timer, STATE, const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbIrq<Timer, STATE, OUTGOING_LEN, INCOMING_LEN>
 where
     Timer: EsbTimer,
 {
     /// Puts the driver in the disabled state
-    pub fn into_disabled(mut self) -> EsbIrq<Timer, Disabled, OutgoingLen, IncomingLen> {
+    pub fn into_disabled(mut self) -> EsbIrq<Timer, Disabled, OUTGOING_LEN, INCOMING_LEN> {
         // Put the radio in a known state
         self.radio.stop(true);
         Timer::clear_interrupt_retransmit();
@@ -152,12 +152,12 @@ where
     }
 }
 
-impl<Timer, const OutgoingLen: usize, const IncomingLen: usize> EsbIrq<Timer, Disabled, OutgoingLen, IncomingLen>
+impl<Timer, const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbIrq<Timer, Disabled, OUTGOING_LEN, INCOMING_LEN>
 where
     Timer: EsbTimer,
 {
     /// Puts the driver in the PTX mode
-    pub fn into_ptx(self) -> EsbIrq<Timer, StatePTX, OutgoingLen, IncomingLen> {
+    pub fn into_ptx(self) -> EsbIrq<Timer, StatePTX, OUTGOING_LEN, INCOMING_LEN> {
         EsbIrq {
             prod_to_app: self.prod_to_app,
             cons_from_app: self.cons_from_app,
@@ -173,7 +173,7 @@ where
 
     /// Puts the driver in the PRX mode in a idle state, the user must call
     /// [start_receiving](struct.EsbIrq.html#method.start_receiving) to enable the radio for receiving
-    pub fn into_prx(self) -> EsbIrq<Timer, StatePRX, OutgoingLen, IncomingLen> {
+    pub fn into_prx(self) -> EsbIrq<Timer, StatePRX, OUTGOING_LEN, INCOMING_LEN> {
         EsbIrq {
             prod_to_app: self.prod_to_app,
             cons_from_app: self.cons_from_app,
@@ -188,7 +188,7 @@ where
     }
 }
 
-impl<Timer, const OutgoingLen: usize, const IncomingLen: usize> EsbIrq<Timer, StatePTX, OutgoingLen, IncomingLen>
+impl<Timer, const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbIrq<Timer, StatePTX, OUTGOING_LEN, INCOMING_LEN>
 where
     Timer: EsbTimer,
 {
@@ -309,7 +309,7 @@ where
     }
 }
 
-impl<Timer, const OutgoingLen: usize, const IncomingLen: usize> EsbIrq<Timer, StatePRX, OutgoingLen, IncomingLen>
+impl<Timer, const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbIrq<Timer, StatePRX, OUTGOING_LEN, INCOMING_LEN>
 where
     Timer: EsbTimer,
 {
@@ -407,7 +407,7 @@ where
 
     fn prepare_receiver<F>(&mut self, f: F) -> Result<(), Error>
     where
-        F: FnOnce(&mut Self, PayloadW<IncomingLen>) -> Result<(), Error>,
+        F: FnOnce(&mut Self, PayloadW<INCOMING_LEN>) -> Result<(), Error>,
     {
         if let Ok(grant) = self
             .prod_to_app

--- a/src/irq.rs
+++ b/src/irq.rs
@@ -107,7 +107,8 @@ struct Events {
     timer: bool,
 }
 
-impl<Timer, STATE, const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbIrq<Timer, STATE, OUTGOING_LEN, INCOMING_LEN>
+impl<Timer, STATE, const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
+    EsbIrq<Timer, STATE, OUTGOING_LEN, INCOMING_LEN>
 where
     Timer: EsbTimer,
 {
@@ -152,7 +153,8 @@ where
     }
 }
 
-impl<Timer, const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbIrq<Timer, Disabled, OUTGOING_LEN, INCOMING_LEN>
+impl<Timer, const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
+    EsbIrq<Timer, Disabled, OUTGOING_LEN, INCOMING_LEN>
 where
     Timer: EsbTimer,
 {
@@ -188,7 +190,8 @@ where
     }
 }
 
-impl<Timer, const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbIrq<Timer, StatePTX, OUTGOING_LEN, INCOMING_LEN>
+impl<Timer, const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
+    EsbIrq<Timer, StatePTX, OUTGOING_LEN, INCOMING_LEN>
 where
     Timer: EsbTimer,
 {
@@ -309,7 +312,8 @@ where
     }
 }
 
-impl<Timer, const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbIrq<Timer, StatePRX, OUTGOING_LEN, INCOMING_LEN>
+impl<Timer, const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
+    EsbIrq<Timer, StatePRX, OUTGOING_LEN, INCOMING_LEN>
 where
     Timer: EsbTimer,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub use crate::{
 
 use core::default::Default;
 // Export dependency items necessary to create a backing structure
-pub use bbqueue::{consts, ArrayLength, BBBuffer, ConstBBBuffer};
+pub use bbqueue::BBBuffer;
 
 // TODO: Figure it out good values
 const RX_WAIT_FOR_ACK_TIMEOUT_US_2MBPS: u16 = 120;

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -256,8 +256,7 @@ pub struct PayloadR<const N: usize> {
     grant: FrameGrantR<'static, N>,
 }
 
-impl<const N: usize> PayloadR<N>
-{
+impl<const N: usize> PayloadR<N> {
     /// Create a wrapped Payload Grant from a raw BBQueue Framed Grant
     pub(crate) fn new(raw_grant: FrameGrantR<'static, N>) -> Self {
         Self { grant: raw_grant }
@@ -321,8 +320,7 @@ impl<const N: usize> PayloadR<N>
     }
 }
 
-impl<const N: usize> Deref for PayloadR<N>
-{
+impl<const N: usize> Deref for PayloadR<N> {
     type Target = [u8];
 
     /// Provide read only access to the payload of a grant
@@ -331,8 +329,7 @@ impl<const N: usize> Deref for PayloadR<N>
     }
 }
 
-impl<const N: usize> DerefMut for PayloadR<N>
-{
+impl<const N: usize> DerefMut for PayloadR<N> {
     /// provide read/write access to the payload portion of the grant
     fn deref_mut(&mut self) -> &mut [u8] {
         &mut self.grant[EsbHeader::header_size()..]
@@ -343,8 +340,7 @@ pub struct PayloadW<const N: usize> {
     grant: FrameGrantW<'static, N>,
 }
 
-impl<const N: usize> PayloadW<N>
-{
+impl<const N: usize> PayloadW<N> {
     /// Update the header contained within this grant.
     ///
     /// This can be used to modify the pipe, length, etc. of the
@@ -485,8 +481,7 @@ impl<const N: usize> PayloadW<N>
     }
 }
 
-impl<const N: usize> Deref for PayloadW<N>
-{
+impl<const N: usize> Deref for PayloadW<N> {
     type Target = [u8];
 
     /// provide read only access to the payload portion of the grant
@@ -495,8 +490,7 @@ impl<const N: usize> Deref for PayloadW<N>
     }
 }
 
-impl<const N: usize> DerefMut for PayloadW<N>
-{
+impl<const N: usize> DerefMut for PayloadW<N> {
     /// provide read/write access to the payload portion of the grant
     fn deref_mut(&mut self) -> &mut [u8] {
         &mut self.grant[EsbHeader::header_size()..]

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,8 +1,5 @@
 use crate::Error;
-use bbqueue::{
-    framed::{FrameGrantR, FrameGrantW},
-    ArrayLength,
-};
+use bbqueue::framed::{FrameGrantR, FrameGrantW};
 use core::ops::{Deref, DerefMut};
 
 // | SW USE                        |               ACTUAL DMA PART                                    |
@@ -255,13 +252,11 @@ impl EsbHeader {
 /// been sent FROM the app, and are being read by the RADIO,
 /// or a payload that has send FROM the Radio, and is being
 /// read by the app
-pub struct PayloadR<N: ArrayLength<u8>> {
+pub struct PayloadR<const N: usize> {
     grant: FrameGrantR<'static, N>,
 }
 
-impl<N> PayloadR<N>
-where
-    N: ArrayLength<u8>,
+impl<const N: usize> PayloadR<N>
 {
     /// Create a wrapped Payload Grant from a raw BBQueue Framed Grant
     pub(crate) fn new(raw_grant: FrameGrantR<'static, N>) -> Self {
@@ -326,9 +321,7 @@ where
     }
 }
 
-impl<N> Deref for PayloadR<N>
-where
-    N: ArrayLength<u8>,
+impl<const N: usize> Deref for PayloadR<N>
 {
     type Target = [u8];
 
@@ -338,9 +331,7 @@ where
     }
 }
 
-impl<N> DerefMut for PayloadR<N>
-where
-    N: ArrayLength<u8>,
+impl<const N: usize> DerefMut for PayloadR<N>
 {
     /// provide read/write access to the payload portion of the grant
     fn deref_mut(&mut self) -> &mut [u8] {
@@ -348,13 +339,11 @@ where
     }
 }
 
-pub struct PayloadW<N: ArrayLength<u8>> {
+pub struct PayloadW<const N: usize> {
     grant: FrameGrantW<'static, N>,
 }
 
-impl<N> PayloadW<N>
-where
-    N: ArrayLength<u8>,
+impl<const N: usize> PayloadW<N>
 {
     /// Update the header contained within this grant.
     ///
@@ -496,9 +485,7 @@ where
     }
 }
 
-impl<N> Deref for PayloadW<N>
-where
-    N: ArrayLength<u8>,
+impl<const N: usize> Deref for PayloadW<N>
 {
     type Target = [u8];
 
@@ -508,9 +495,7 @@ where
     }
 }
 
-impl<N> DerefMut for PayloadW<N>
-where
-    N: ArrayLength<u8>,
+impl<const N: usize> DerefMut for PayloadW<N>
 {
     /// provide read/write access to the payload portion of the grant
     fn deref_mut(&mut self) -> &mut [u8] {

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -46,17 +46,17 @@ pub(crate) enum RxPayloadState {
     BadCRC,
 }
 
-pub struct EsbRadio<const OutgoingLen: usize, const IncomingLen: usize>
+pub struct EsbRadio<const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
 {
     radio: RADIO,
-    tx_grant: Option<PayloadR<OutgoingLen>>,
-    rx_grant: Option<PayloadW<IncomingLen>>,
+    tx_grant: Option<PayloadR<OUTGOING_LEN>>,
+    rx_grant: Option<PayloadW<INCOMING_LEN>>,
     last_crc: [u16; NUM_PIPES],
     last_pid: [u8; NUM_PIPES],
     cached_pipe: u8,
 }
 
-impl<const OutgoingLen: usize, const IncomingLen: usize> EsbRadio<OutgoingLen, IncomingLen>
+impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbRadio<OUTGOING_LEN, INCOMING_LEN>
 {
     pub(crate) fn new(radio: RADIO) -> Self {
         EsbRadio {
@@ -204,7 +204,7 @@ impl<const OutgoingLen: usize, const IncomingLen: usize> EsbRadio<OutgoingLen, I
     // --------------- PTX methods --------------- //
 
     // Transmit a packet and setup interrupts.
-    pub(crate) fn transmit(&mut self, payload: PayloadR<OutgoingLen>, ack: bool) {
+    pub(crate) fn transmit(&mut self, payload: PayloadR<OUTGOING_LEN>, ack: bool) {
         if ack {
             // Go to RX mode after the transmission
             self.radio.shorts.modify(|_, w| w.disabled_rxen().enabled());
@@ -254,7 +254,7 @@ impl<const OutgoingLen: usize, const IncomingLen: usize> EsbRadio<OutgoingLen, I
 
     // Must be called after the end of TX if the user requested for an ack.
     // Timers must be set accordingly by the upper stack
-    pub(crate) fn prepare_for_ack(&mut self, mut rx_buf: PayloadW<IncomingLen>) {
+    pub(crate) fn prepare_for_ack(&mut self, mut rx_buf: PayloadW<INCOMING_LEN>) {
         self.clear_ready_event();
         // We need a compiler fence here because the DMA will automatically start listening for
         // packets after the ramp-up is completed
@@ -309,7 +309,7 @@ impl<const OutgoingLen: usize, const IncomingLen: usize> EsbRadio<OutgoingLen, I
     // --------------- PRX methods --------------- //
 
     // Start listening for packets and setup necessary shorts and interrupts
-    pub(crate) fn start_receiving(&mut self, mut rx_buf: PayloadW<IncomingLen>, enabled_pipes: u8) {
+    pub(crate) fn start_receiving(&mut self, mut rx_buf: PayloadW<INCOMING_LEN>, enabled_pipes: u8) {
         // Start TX after receiving a packet as it might need an ack
         self.radio.shorts.modify(|_, w| w.disabled_txen().enabled());
 
@@ -340,7 +340,7 @@ impl<const OutgoingLen: usize, const IncomingLen: usize> EsbRadio<OutgoingLen, I
     #[inline]
     pub(crate) fn check_packet(
         &mut self,
-        consumer: &mut FrameConsumer<'static, OutgoingLen>,
+        consumer: &mut FrameConsumer<'static, OUTGOING_LEN>,
     ) -> Result<RxPayloadState, Error> {
         // If the user didn't provide a packet to send, we will fall back to this empty ack packet
         static FALLBACK_ACK: [u8; 2] = [0, 0];
@@ -450,7 +450,7 @@ impl<const OutgoingLen: usize, const IncomingLen: usize> EsbRadio<OutgoingLen, I
     // `rx_buf` must only be `None` if a previous call to `check_packet` returned `RepeatedAck`
     pub(crate) fn complete_rx_ack(
         &mut self,
-        mut rx_buf: Option<PayloadW<IncomingLen>>,
+        mut rx_buf: Option<PayloadW<INCOMING_LEN>>,
     ) -> Result<(), Error> {
         let dma_pointer = if let Some(mut grant) = rx_buf.take() {
             let pointer = grant.dma_pointer() as u32;
@@ -483,7 +483,7 @@ impl<const OutgoingLen: usize, const IncomingLen: usize> EsbRadio<OutgoingLen, I
 
     // Must be called after `check_packet` returns `RxPayloadState::NoAck`.
     // `rx_buf` must only be `None` if a previous call to `check_packet` returned `RepeatedNoAck`
-    pub(crate) fn complete_rx_no_ack(&mut self, mut rx_buf: Option<PayloadW<IncomingLen>>) {
+    pub(crate) fn complete_rx_no_ack(&mut self, mut rx_buf: Option<PayloadW<INCOMING_LEN>>) {
         // Since we're in the no-ack branch, the previous value of `packetptr` still is the last
         // `rx_grant` that we still hold if `check_packet` returned `RepeatedNoAck`. Therefore, we
         // only need to update if `rx_buf` is `Some`.

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -46,8 +46,7 @@ pub(crate) enum RxPayloadState {
     BadCRC,
 }
 
-pub struct EsbRadio<const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
-{
+pub struct EsbRadio<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> {
     radio: RADIO,
     tx_grant: Option<PayloadR<OUTGOING_LEN>>,
     rx_grant: Option<PayloadW<INCOMING_LEN>>,
@@ -56,8 +55,7 @@ pub struct EsbRadio<const OUTGOING_LEN: usize, const INCOMING_LEN: usize>
     cached_pipe: u8,
 }
 
-impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbRadio<OUTGOING_LEN, INCOMING_LEN>
-{
+impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbRadio<OUTGOING_LEN, INCOMING_LEN> {
     pub(crate) fn new(radio: RADIO) -> Self {
         EsbRadio {
             radio,
@@ -309,7 +307,11 @@ impl<const OUTGOING_LEN: usize, const INCOMING_LEN: usize> EsbRadio<OUTGOING_LEN
     // --------------- PRX methods --------------- //
 
     // Start listening for packets and setup necessary shorts and interrupts
-    pub(crate) fn start_receiving(&mut self, mut rx_buf: PayloadW<INCOMING_LEN>, enabled_pipes: u8) {
+    pub(crate) fn start_receiving(
+        &mut self,
+        mut rx_buf: PayloadW<INCOMING_LEN>,
+        enabled_pipes: u8,
+    ) {
         // Start TX after receiving a packet as it might need an ack
         self.radio.shorts.modify(|_, w| w.disabled_txen().enabled());
 

--- a/src/peripherals.rs
+++ b/src/peripherals.rs
@@ -13,7 +13,7 @@ use nrf52833_pac as pac;
 #[cfg(feature = "52840")]
 use nrf52840_pac as pac;
 
-use bbqueue::{framed::FrameConsumer, ArrayLength};
+use bbqueue::framed::FrameConsumer;
 use core::sync::atomic::{compiler_fence, Ordering};
 
 use crate::{
@@ -46,10 +46,7 @@ pub(crate) enum RxPayloadState {
     BadCRC,
 }
 
-pub struct EsbRadio<OutgoingLen, IncomingLen>
-where
-    OutgoingLen: ArrayLength<u8>,
-    IncomingLen: ArrayLength<u8>,
+pub struct EsbRadio<const OutgoingLen: usize, const IncomingLen: usize>
 {
     radio: RADIO,
     tx_grant: Option<PayloadR<OutgoingLen>>,
@@ -59,10 +56,7 @@ where
     cached_pipe: u8,
 }
 
-impl<OutgoingLen, IncomingLen> EsbRadio<OutgoingLen, IncomingLen>
-where
-    OutgoingLen: ArrayLength<u8>,
-    IncomingLen: ArrayLength<u8>,
+impl<const OutgoingLen: usize, const IncomingLen: usize> EsbRadio<OutgoingLen, IncomingLen>
 {
     pub(crate) fn new(radio: RADIO) -> Self {
         EsbRadio {


### PR DESCRIPTION
This is a compiling set of changes that update esb to bbqueue 0.5.1. I have also updated the docs where I saw any mentions, and removed the "public `EsbBuffer` fields". Changelog has been updated.

Still to do:

- [ ] test on physical units (so far, just compiling and tests passing)
- [x] cargo fmt (waiting until ready to merge)
- [ ] Update version number (do in a separate PR?) + release